### PR TITLE
Fix FormSelect warnings on Forms page.

### DIFF
--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -104,11 +104,6 @@ var Forms = React.createClass({
 			);
 		});
 
-		var options = [1, 2, 3, 4, 5].map(function(item) {
-			return <option key={'option-' + item} value={item}>Option {item}</option>;
-		});
-
-
 		// Icon Loops
 
 		var iconContextVariantsColor = COLOR_VARIANTS.map(function(color) {
@@ -265,9 +260,9 @@ var Forms = React.createClass({
 						<FormInput placeholder="Textarea" name="supported-controls-textarea" multiline />
 					</FormField>
 					<FormField label="Select" htmlFor="supported-controls-select">
-						<FormSelect options={options} firstOption="Select" />
+						<FormSelect options={controlOptions} firstOption="Select" onChange={updateSelect} />
 					</FormField>
-					<FormSelect label="Disabled Select" options={options} htmlFor="supported-conrols-select-disabled" firstOption="Disabled Select" disabled />
+					<FormSelect label="Disabled Select" options={controlOptions} onChange={updateSelect} htmlFor="supported-conrols-select-disabled" firstOption="Disabled Select" disabled />
 					<FormField label="Checkboxes">
 						{checkboxes}
 					</FormField>
@@ -335,7 +330,7 @@ var Forms = React.createClass({
 							<FormInput width="one-third" placeholder="Post Code" name="city" />
 						</FormField>
 						<FormField width="two-thirds">
-							<FormSelect options={countryOptions} firstOption="Country" />
+							<FormSelect options={countryOptions} firstOption="Country" onChange={updateSelect} />
 						</FormField>
 					</FormRow>
 				</form>


### PR DESCRIPTION
Fix for #13. :sparkle: 

Also fix for a couple of warnings:
```
Warning: Failed propType: Required prop `onChange` was not specified in `FormSelect`. Check the render method of `VIEW_Forms`.
```
and
```
Warning: Failed propType: Invalid prop `value` of type `object` supplied to `FormSelect`, expected `string`. Check the render method of `VIEW_Forms`.
```

And I was wrong about `controlOptions` => `options` in #12. Also fixing it. :sparkle: 