### PR TITLE
Fix bug with blacklist package usage.

### DIFF
--- a/lib/components/Alert.js
+++ b/lib/components/Alert.js
@@ -20,7 +20,7 @@ module.exports = React.createClass({
 	render: function render() {
 		var componentClass = classNames('Alert', 'Alert--' + this.props.type, this.props.className);
 
-		var props = blacklist(this.props, ['type', 'className']);
+		var props = blacklist(this.props, 'type', 'className');
 
 		return React.createElement(
 			'div',

--- a/lib/components/Button.js
+++ b/lib/components/Button.js
@@ -29,7 +29,7 @@ module.exports = React.createClass({
 		}, this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['type', 'size', 'className']);
+		var props = blacklist(this.props, 'type', 'size', 'className');
 		props.className = componentClass;
 
 		var tag = 'button';

--- a/lib/components/Dropdown.js
+++ b/lib/components/Dropdown.js
@@ -110,7 +110,7 @@ module.exports = React.createClass({
 		}, this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['alignRight', 'buttonHasDisclosureArrow', 'buttonLabel', 'buttonType', 'className', 'isOpen', 'items']);
+		var props = blacklist(this.props, 'alignRight', 'buttonHasDisclosureArrow', 'buttonLabel', 'buttonType', 'className', 'isOpen', 'items');
 
 		return React.createElement(
 			'span',

--- a/lib/components/FormIconField.js
+++ b/lib/components/FormIconField.js
@@ -27,7 +27,7 @@ module.exports = React.createClass({
 	},
 	render: function render() {
 		// props
-		var props = blacklist(this.props, ['className', 'iconPosition', 'iconKey', 'iconFill', 'iconColor', 'iconIsLoading']);
+		var props = blacklist(this.props, 'className', 'iconPosition', 'iconKey', 'iconFill', 'iconColor', 'iconIsLoading');
 
 		// classes
 		var fieldClass = classNames('IconField', {

--- a/lib/components/FormLabel.js
+++ b/lib/components/FormLabel.js
@@ -17,7 +17,7 @@ module.exports = React.createClass({
 		var className = classNames('form-label', this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['htmlFor', 'id', 'className', 'style']);
+		var props = blacklist(this.props, 'htmlFor', 'id', 'className', 'style');
 
 		// style
 		var style;

--- a/lib/components/FormRow.js
+++ b/lib/components/FormRow.js
@@ -14,7 +14,7 @@ module.exports = React.createClass({
 		var className = classNames('form-row', this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['className']);
+		var props = blacklist(this.props, 'className');
 
 		return React.createElement(
 			'div',

--- a/lib/components/FormSelect.js
+++ b/lib/components/FormSelect.js
@@ -72,7 +72,7 @@ module.exports = React.createClass({
 	},
 	render: function render() {
 		// props
-		var props = blacklist(this.props, ['prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value', 'className']);
+		var props = blacklist(this.props, 'prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value', 'className');
 
 		// classes
 		var componentClass = classNames('form-field', {

--- a/lib/components/Modal.js
+++ b/lib/components/Modal.js
@@ -17,7 +17,7 @@ module.exports = React.createClass({
 	},
 	render: function render() {
 		// props
-		var props = blacklist(this.props, ['backdropClosesModal', 'className', 'headerHasCloseButton', 'headerTitle', 'isOpen']);
+		var props = blacklist(this.props, 'backdropClosesModal', 'className', 'headerHasCloseButton', 'headerTitle', 'isOpen');
 
 		// classes
 		var dialogClass = classNames('Modal-dialog', this.props.className);

--- a/lib/components/RadioGroup.js
+++ b/lib/components/RadioGroup.js
@@ -71,7 +71,7 @@ module.exports = React.createClass({
 		var self = this;
 
 		// props
-		var props = blacklist(this.props, ['alwaysValidate', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value']);
+		var props = blacklist(this.props, 'alwaysValidate', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value');
 
 		// classes
 		var componentClass = classNames('form-field', {

--- a/lib/components/Tooltip.js
+++ b/lib/components/Tooltip.js
@@ -44,7 +44,7 @@ module.exports = React.createClass({
 		var componentClass = classNames('TooltipOuter', this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['content', 'className', 'placement', 'target']);
+		var props = blacklist(this.props, 'content', 'className', 'placement', 'target');
 
 		// style
 		var tooltipStyle = {};

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -51,7 +51,7 @@ module.exports = React.createClass({
 		);
 
 		// props
-		var props = blacklist(this.props, ['type', 'size', 'className']);
+		var props = blacklist(this.props, 'type', 'size', 'className');
 		props.className = componentClass;
 
 		var tag = 'button';

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -99,7 +99,7 @@ module.exports = React.createClass({
 		}, this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['alignRight', 'buttonHasDisclosureArrow', 'buttonLabel', 'buttonType', 'className', 'isOpen', 'items']);
+		var props = blacklist(this.props, 'alignRight', 'buttonHasDisclosureArrow', 'buttonLabel', 'buttonType', 'className', 'isOpen', 'items');
 
 		return (
 			<span className={dropdownClass} {...props}>

--- a/src/components/FormIconField.js
+++ b/src/components/FormIconField.js
@@ -25,7 +25,7 @@ module.exports = React.createClass({
 	},
 	render() {
 		// props
-		var props = blacklist(this.props, ['className', 'iconPosition', 'iconKey', 'iconFill', 'iconColor', 'iconIsLoading']);
+		var props = blacklist(this.props, 'className', 'iconPosition', 'iconKey', 'iconFill', 'iconColor', 'iconIsLoading');
 
 
 		// classes

--- a/src/components/FormLabel.js
+++ b/src/components/FormLabel.js
@@ -17,7 +17,7 @@ module.exports = React.createClass({
 
 
 		// props
-		var props = blacklist(this.props, ['htmlFor', 'id', 'className', 'style']);
+		var props = blacklist(this.props, 'htmlFor', 'id', 'className', 'style');
 
 
 		// style

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -70,7 +70,7 @@ module.exports = React.createClass({
 	},
 	render() {
 		// props
-		var props = blacklist(this.props, ['prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value', 'className']);
+		var props = blacklist(this.props, 'prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value', 'className');
 
 		// classes
 		var componentClass = classNames('form-field', {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -41,7 +41,7 @@ module.exports = React.createClass({
 		var className = classNames('Modal', this.props.className);
 
 		// props
-		var props = blacklist(this.props, ['backdropClosesModal', 'className', 'headerHasCloseButton', 'headerTitle', 'isOpen']);
+		var props = blacklist(this.props, 'backdropClosesModal', 'className', 'headerHasCloseButton', 'headerTitle', 'isOpen');
 		props.className = className;
 
 		return (

--- a/src/components/RadioGroup.js
+++ b/src/components/RadioGroup.js
@@ -69,7 +69,7 @@ module.exports = React.createClass({
 		var self = this;
 
 		// props
-		var props = blacklist(this.props, ['alwaysValidate', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value']);
+		var props = blacklist(this.props, 'alwaysValidate', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'value');
 
 		// classes
 		var componentClass = classNames('form-field', {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -78,7 +78,7 @@ module.exports = React.createClass({
 
 	render() {
 		// props
-		var props = blacklist(this.props, ['content', 'placement', 'target']);
+		var props = blacklist(this.props, 'content', 'placement', 'target');
 
 		return (
 			<span ref="target" onMouseOver={this.showTooltip} onMouseOut={this.hideTooltip} onFocus={this.showTooltip} onBlur={this.hideTooltip} style={{ position: 'relative' }} {...props}>


### PR DESCRIPTION
When I was fixing #13, I've found out that `option` always is DOM event object instead of `e.target.value` here [Forms.js#L70](https://github.com/AlexKVal/elemental/blob/eb418e03361d04b14831d765dbacc85074bd7b3b/site/src/pages/Forms.js#L70)

It is because of `onChange` from `{...props}` overrides `onChange={this.handleChange}` here [FormSelect.js#L103](https://github.com/AlexKVal/elemental/blob/9a6a8c4d4932b6a1ebde199c551c4cbf1463bc67/src/components/FormSelect.js#L103)

if I place `{...props}` *before* `onChange=`, like this
```js
<select className="FormInput" id={forAndID} {...props} onChange={this.handleChange} onBlur={this.handleBlur}>
```
then the right `this.handleChange` is fired and everything works fine.

The cause it that  `blacklist` doesn't filter out `onChange` here [FormSelect.js#L73](https://github.com/AlexKVal/elemental/blob/9a6a8c4d4932b6a1ebde199c551c4cbf1463bc67/src/components/FormSelect.js#L73)

And I found the same issue with `RadioGroup`.

Then I looked at `blacklist` source and realized that usage of it is wrong.

By searching of `blacklist(this.props...` throughout the project and fixing,
I've made this PR. 

With `npm run start` all elements are now working as expected. :tada: 
:cherries: 