### PR TITLE
Just proposal. Impose "object-curly-spacing" eslint rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
 		"key-spacing": 0,
 		"no-multi-spaces": 0,
 		"no-underscore-dangle": 0,
+		"object-curly-spacing": [1, "always"],
 		"react/display-name": 0,
 		"react/jsx-boolean-value": 1,
 		"react/jsx-quotes": 1,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^3.1.5",
-    "eslint": "^0.21.1",
+    "eslint": "^0.22.1",
     "eslint-plugin-react": "^2.3.0",
     "gulp": "^3.8.11",
     "react": "^0.13.3",

--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -67,16 +67,16 @@ var Forms = React.createClass({
 
 		// handle form input and validation
 		function updateSelect(option) {
-			self.setState({inputSelect: option});
+			self.setState({ inputSelect: option });
 		}
 		function updateInlineRadios(option) {
-			self.setState({inlineRadioGroup: option});
+			self.setState({ inlineRadioGroup: option });
 		}
 		function updateEmail(e) {
-			self.setState({inputEmail: e.target.value});
+			self.setState({ inputEmail: e.target.value });
 		}
 		function updatePassword(e) {
-			self.setState({inputPassword: e.target.value});
+			self.setState({ inputPassword: e.target.value });
 		}
 
 		// elements

--- a/site/src/pages/Modal.js
+++ b/site/src/pages/Modal.js
@@ -32,10 +32,10 @@ module.exports = React.createClass({
 
 		// handle form input and validation
 		function updateEmail(e) {
-			self.setState({inputEmail: e.target.value});
+			self.setState({ inputEmail: e.target.value });
 		}
 		function updatePassword(e) {
-			self.setState({inputPassword: e.target.value});
+			self.setState({ inputPassword: e.target.value });
 		}
 
 		var submitButton = this.state.formProcessing ? (

--- a/src/components/FileDragAndDrop.js
+++ b/src/components/FileDragAndDrop.js
@@ -71,7 +71,7 @@ var Dropzone = React.createClass({
 
 		return (
 			<button className={className} onClick={this.onClick} onDragLeave={this.onDragLeave} onDragOver={this.onDragOver} onDrop={this.onDrop}>
-				<input style={{display: 'none' }} type='file' multiple ref='fileInput' onChange={this.onDrop} />
+				<input style={{ display: 'none' }} type='file' multiple ref='fileInput' onChange={this.onDrop} />
 				<div className="FileDragAndDrop__label">{this.state.isDragActive ? this.props.labelActive : this.props.label}</div>
 				{this.props.children}
 			</button>

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -93,7 +93,7 @@ module.exports = React.createClass({
 		return (
 			<div>
 				{component}
-				<input style={{display: 'none' }} type="file" ref="fileInput" onChange={this.handleChange} {...props} />
+				<input style={{ display: 'none' }} type="file" ref="fileInput" onChange={this.handleChange} {...props} />
 			</div>
 		);
 	}


### PR DESCRIPTION
The new "object-curly-spacing" eslint rule https://github.com/eslint/eslint/pull/2515/files has been finally implemented.
It seems it is long awaited https://github.com/eslint/eslint/issues/2225#issue-66089460.

But it doesn't work for JSX. 
E.g. there is no warning here [FileDragAndDrop.js#L76](https://github.com/elementalui/elemental/blob/3a46a41965be0ac9d0aa9a775597cd8d20974298/src/components/FileDragAndDrop.js#L76)

And it won't be implemented in `eslint` according to https://github.com/eslint/eslint/issues/2225#issuecomment-89345117
> It should apply to restructured objects but not JSX.

Maybe [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) eventually will implement it. (if someone creates feature requests)