### PR TITLE
Use React.cloneElement() for child elements.

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -37,9 +37,13 @@ module.exports = React.createClass({
 
 	renderChildren () {
 		return React.Children.map(this.props.children, (child) => {
-			child.props.onClick = this.state.isOpen ? this.closeDropdown : this.openDropdown;
-			child.props.className = classNames(child.props.className, 'Dropdown-toggle');
-			return child;
+			return React.cloneElement(
+				child,
+				{
+					onClick: this.state.isOpen ? this.closeDropdown : this.openDropdown,
+					className: classNames(child.props.className, 'Dropdown-toggle')
+				}
+			);
 		});
 	},
 	renderButton () {


### PR DESCRIPTION
Eliminates 
```
Warning: Don't set .props.onClick of the React component <h3 />.
...
Warning: Don't set .props.className of the React component <h3 />.
```
on the http://elemental-ui.com/buttons page.