### PR TITLE
 Select input styling is broken in Firefox #22

### DIFF
--- a/less/components/FormInput.less
+++ b/less/components/FormInput.less
@@ -23,6 +23,7 @@
 	padding: 0 @input-padding-horizontal;
 	width: 100%;
 	-webkit-appearance: none;
+	-moz-appearance: none;
 
 
 	// states


### PR DESCRIPTION
Fixed:


![20150610-100858](https://cloud.githubusercontent.com/assets/175264/8072395/be2e52ea-0f58-11e5-9a97-f673dbc170f8.png)
