### PR TITLE
Modal box is opened out of screen #24

### DIFF
--- a/site/src/pages/Modal.js
+++ b/site/src/pages/Modal.js
@@ -49,8 +49,20 @@ module.exports = React.createClass({
 		return (
 			<div className="demo-container container">
 				<h1>Modal</h1>
-				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ac viverra augue. Vivamus ultricies nec massa a vulputate. Donec non lacus sit amet augue faucibus sodales ut at nulla. Donec id tincidunt nulla. Aenean sit amet libero velit. Nam maximus leo sit amet dolor tincidunt egestas. Nunc facilisis tellus et sapien consectetur varius. In ligula orci, tincidunt eu molestie sit amet, facilisis in nisl. Cras elit risus, scelerisque quis elementum sed, convallis a mi. Etiam placerat eros vitae hendrerit varius.</p>
-				<p>Morbi maximus metus diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Nulla dolor felis, vulputate quis imperdiet vel, molestie tincidunt dui. Nulla aliquet ut lorem ac dignissim. Cras sem lectus, iaculis quis mi quis, convallis euismod massa. Fusce augue ipsum, consectetur ut nisl vel, convallis varius felis. Aenean finibus id justo et varius.</p>
+				<p>Buy why, some say, the moon? Why choose this as our goal? And they may as well ask why climb the highest mountain?</p>
+				<p>The sky is the limit only for those who aren't afraid to fly!</p>
+				<p>As we got further and further away, it [the Earth] diminished in size. Finally it shrank to the size of a marble, the most beautiful you can imagine. That beautiful, warm, living object looked so fragile, so delicate, that if you touched it with a finger it would crumble and fall apart. Seeing this has to change a man.</p>
+				<Button onClick={this.toggleModal}>Launch Modal</Button>
+				<p>If you could see the earth illuminated when you were in a place as dark as night, it would look to you more splendid than the moon.</p>
+				<p>NASA is not about the ‘Adventure of Human Space Exploration’…We won’t be doing it just to get out there in space – we’ll be doing it because the things we learn out there will be making life better for a lot of people who won’t be able to go.</p>
+				<p>It suddenly struck me that that tiny pea, pretty and blue, was the Earth. I put up my thumb and shut one eye, and my thumb blotted out the planet Earth. I didn't feel like a giant. I felt very, very small.</p>
+				<p>We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win.</p>
+				<p>Science cuts two ways, of course; its products can be used for both good and evil. But there's no turning back from science. The early warnings about technological dangers also come from science.</p>
+				<p>It suddenly struck me that that tiny pea, pretty and blue, was the Earth. I put up my thumb and shut one eye, and my thumb blotted out the planet Earth. I didn't feel like a giant. I felt very, very small.</p>
+				<p>Science has not yet mastered prophecy. We predict too much for the next year and yet far too little for the next 10.</p>
+				<p>We have an infinite amount to learn both from nature and from each other</p>
+				<p>The Earth was small, light blue, and so touchingly alone, our home that must be defended like a holy relic. The Earth was absolutely round. I believe I never knew what the word round meant until I saw Earth from space.</p>
+				<p>We want to explore. We’re curious people. Look back over history, people have put their lives at stake to go out and explore … We believe in what we’re doing. Now it’s time to go.</p>
 				<Button onClick={this.toggleModal}>Launch Modal</Button>
 				<Modal isOpen={this.state.modalIsOpen} onCancel={this.toggleModal} headerTitle="Modal Header" headerHasCloseButton backdropClosesModal>
 					<form>

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -11,7 +11,8 @@ module.exports = React.createClass({
 		headerHasCloseButton: React.PropTypes.bool,
 		headerTitle: React.PropTypes.string,
 		isOpen: React.PropTypes.bool,
-		onCancel: React.PropTypes.func
+		onCancel: React.PropTypes.func,
+		top: React.PropTypes.number
 	},
 	renderDialog() {
 		if (!this.props.isOpen) return null;
@@ -22,8 +23,10 @@ module.exports = React.createClass({
 			<h4 className="Modal-title">{this.props.headerTitle}</h4>
 		</div> : null;
 
+		var top = typeof this.props.top !== 'undefined' ? this.props.top : window.pageYOffset;
+
 		return (
-			<div className="Modal-dialog">
+			<div className="Modal-dialog" style={{top: `${top}px`}}>
 				<div className="Modal-content">
 					{header}
 					{this.props.children}

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -26,7 +26,7 @@ module.exports = React.createClass({
 		var top = typeof this.props.top !== 'undefined' ? this.props.top : window.pageYOffset;
 
 		return (
-			<div className="Modal-dialog" style={{top: `${top}px`}}>
+			<div className="Modal-dialog" style={{top}}>
 				<div className="Modal-content">
 					{header}
 					{this.props.children}


### PR DESCRIPTION
1. I've used only pageYOffset since there is no support for <IE9
2. Added more random text to Modal page so we can see fix working
3. Added `props.top` so it is possible to override automatic placement. Could be also set to skip `window.pageYOffset` evaluation in case `window` object is not available at all