### PR TITLE
Modal should follow scroll (fixes #26)

### DIFF
--- a/less/components/Modal.less
+++ b/less/components/Modal.less
@@ -31,6 +31,7 @@
 	top: 0;
 	width: 100%;
 	z-index: @zindex-modal;
+	transition: top 200ms linear;
 }
 .Modal-dialog-enter {
 	.animation-name( modalDialogEnter );

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "blacklist": "^1.1.2",
     "classnames": "^2.1.2",
     "moment": "^2.10.3",
-    "react-date-select": "0.0.7"
+    "react-date-select": "0.0.7",
+    "react-interval": "^1.0.4"
   },
   "devDependencies": {
     "babel-eslint": "^3.1.17",


### PR DESCRIPTION
It looks sluggish on gif, but in fact is pretty smooth.

![modal](https://cloud.githubusercontent.com/assets/175264/8983365/3e983960-370d-11e5-8924-62ff94858aaa.gif)

I added this to the demo modal box to test modal that is higher then screen:
```js
<ModalFooter>
  {submitButton}
  <Button onClick={this.toggleModal} type="link-cancel" disabled={this.state.formProcessing}>Cancel</Button>
</ModalFooter>
<div style={{background: 'linear-gradient(to bottom, rgba(201,222,150,1) 0%,rgba(138,182,107,1) 44%,rgba(57,130,53,1) 100%)', height: window.innerHeight}} />
```