### PR TITLE
enable custom password validator in PasswordInputGroup

### DIFF
--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -47,7 +47,8 @@ var Forms = React.createClass({
 	getInitialState () {
 		return {
 			'inputEmail': '',
-			'inputPassword': ''
+			'inputPassword': '',
+			'inputConfirm': ''
 		};
 	},
 
@@ -84,6 +85,12 @@ var Forms = React.createClass({
 		}
 		function updatePassword(e) {
 			self.setState({ inputPassword: e.target.value });
+		}
+		function updateConfirm(e) {
+			self.setState({ inputConfirm: e.target.value });
+		}
+		function validateConfirm(value) {
+			return value === self.state.inputPassword;
 		}
 
 		// elements
@@ -782,6 +789,7 @@ var Forms = React.createClass({
 					<FormSelect         label="Select"   value={this.state.inputSelect}      onChange={updateSelect} options={controlOptions} htmlFor="inputSelect" required prependEmptyOption />
 					<EmailInputGroup    label="Email"    value={this.state.inputEmail}       onChange={updateEmail}    required />
 					<PasswordInputGroup label="Password" value={this.state.inputPassword}    onChange={updatePassword} required />
+					<PasswordInputGroup label="Confirm"  value={this.state.inputConfirm}     onChange={updateConfirm}  required validatePassword={validateConfirm} invalidMessage="Password confirmation doesn't match password" />
 				</form>
 
 

--- a/src/components/PasswordInputGroup.js
+++ b/src/components/PasswordInputGroup.js
@@ -10,6 +10,7 @@ module.exports = React.createClass({
 	propTypes: {
 		alwaysValidate: React.PropTypes.bool,
 		className: React.PropTypes.string,
+		validatePassword: React.PropTypes.func,
 		invalidMessage: React.PropTypes.string,
 		label: React.PropTypes.string,
 		onChange: React.PropTypes.func,
@@ -19,6 +20,7 @@ module.exports = React.createClass({
 	},
 	getDefaultProps() {
 		return {
+			validatePassword,
 			requiredMessage: 'Password is required',
 			invalidMessage: 'Password must be at least 8 characters in length'
 		};

--- a/src/components/PasswordInputGroup.js
+++ b/src/components/PasswordInputGroup.js
@@ -62,7 +62,7 @@ module.exports = React.createClass({
 		var newState = {
 			isValid: true
 		};
-		if ((value.length && !validatePassword(value)) || (!value.length && this.props.required)) {
+		if ((value.length && !this.props.validatePassword(value)) || (!value.length && this.props.required)) {
 			newState.isValid = false;
 		}
 		if (!newState.isValid) {


### PR DESCRIPTION
It would be nice to set the password validator by passing it via `props` to fit various application requirements.
Moreover, I noticed that the feature can be utilized to build confirm password field, where an example is given in the `sites/Forms.js`.