### PR TITLE
Allow `Col` to have no children

### DIFF
--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -10,7 +10,7 @@ module.exports = React.createClass({
 			React.PropTypes.number, // allow pixels
 			React.PropTypes.string, // allow percentage
 		]),
-		children: React.PropTypes.node.isRequired,
+		children: React.PropTypes.node,
 		gutter: React.PropTypes.number,
 		style: React.PropTypes.object,
 		lg: React.PropTypes.string, // width as a percentage or fraction


### PR DESCRIPTION
Often you want a `<Col>` merely for layout purposes / with no content. Seems to currently work fine when using `<Col/>` except there is a prop warning. One can do `<Col><span/></Col>` and everything still works and no error. This just gets rid of the children requirement.