### PR TITLE
Add `component` prop to `Button`, which is rendered instead of creating a `<a>` or `<button>`

### DIFF
--- a/site/src/pages/Buttons.js
+++ b/site/src/pages/Buttons.js
@@ -180,6 +180,12 @@ var Buttons = React.createClass({
 								<td className="usage-table__description">When provided the component will render as an <code className="inline-code">&lt;a&gt;</code> instead of <code className="inline-code">&lt;button&gt;</code></td>
 							</tr>
 							<tr>
+								<td className="usage-table__prop">component</td>
+								<td className="usage-table__type">element</td>
+								<td className="usage-table__default">undefined</td>
+								<td className="usage-table__description">When provided, <code className="inline-code">&lt;Button&gt;</code> will render the passed in component with the proper styles instead of creating its own. This is useful when integrating with React Router's <code className="inline-code">&lt;Link&gt;</code> or using your own custom component</td>
+							</tr>
+							<tr>
 								<td className="usage-table__prop">size</td>
 								<td className="usage-table__type">enum</td>
 								<td className="usage-table__default">''</td>

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -30,6 +30,7 @@ module.exports = React.createClass({
 		block: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		href: React.PropTypes.string,
+		component: React.PropTypes.node,
 		isActive: React.PropTypes.bool,
 		size: React.PropTypes.oneOf(BUTTON_SIZES),
 		submit: React.PropTypes.bool,
@@ -54,8 +55,12 @@ module.exports = React.createClass({
 		);
 
 		// props
-		var props = blacklist(this.props, 'type', 'size', 'className');
+		var props = blacklist(this.props, 'type', 'size', 'component', 'className');
 		props.className = componentClass;
+
+		if (this.props.component) {
+			return React.cloneElement(this.props.component, props);
+		}
 
 		var tag = 'button';
 		props.type = this.props.submit ? 'submit' : 'button';


### PR DESCRIPTION
This is useful for integrating React Router's `<Link>` elements (http://rackt.github.io/react-router/#Link).

Not sure this is the best way to go about it (I'm a JS n00b), feel free to give me feedback!

Why I needed to do this:

* If I wrap a `<Button>` in a React Router `<Link>`, it is rendered as `<a><button>` instead of just a `<a>`. This screws up some styling and semantics.
* I can't get the raw `href` value from React Router to pass to `<Button>` before the component has rendered (AFAIK).
* I can imagine a world where someone would want to create their own `<CustomLink>` or whatever and have that passed through instead of using a raw `<a>`.