### PR TITLE
Add testing setup with Tape and Isparta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,7 @@ lib
 # Dependencies
 node_modules
 
+/coverage/
+
 # Editor files
 *.swp

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
+/coverage/
+/test/
 .*
 dist
 public

--- a/package.json
+++ b/package.json
@@ -15,16 +15,21 @@
     "classnames": "^2.2.0"
   },
   "devDependencies": {
+    "babel": "^5.8.23",
     "babel-eslint": "^4.1.3",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.12.0",
+    "glob": "^5.0.14",
     "gulp": "^3.9.0",
     "history": "^1.17.0",
+    "isparta": "^3.0.4",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-addons-css-transition-group": "^0.14.0",
     "react-component-gulp-tasks": "^0.7.7",
-    "react-router": "1.0.2"
+    "react-router": "1.0.2",
+    "rimraf": "^2.4.3",
+    "tape": "^4.2.0"
   },
   "peerDependencies": {
     "react": "^0.14.0",
@@ -47,7 +52,10 @@
     "release": "gulp release",
     "site": "gulp dev:server",
     "start": "gulp dev",
-    "watch": "gulp watch:lib"
+    "watch": "gulp watch:lib",
+    "test": "babel-node test",
+    "precov": "rimraf coverage",
+    "cov": "babel-node node_modules/isparta/bin/isparta cover --report text --report html test"
   },
   "keywords": [
     "react",

--- a/test/components/Pagination-test.js
+++ b/test/components/Pagination-test.js
@@ -1,4 +1,4 @@
-import {test} from 'tape';
+import { test } from 'tape';
 import Pagination from '../../lib/components/Pagination';
 import React from 'react/addons';
 const TestUtils = React.addons.TestUtils;

--- a/test/components/Pagination-test.js
+++ b/test/components/Pagination-test.js
@@ -20,33 +20,33 @@ const getList = props => createComponent(Pagination, props).props.children[1];
 
 test('Pagination. Basics', t => {
 
-	t.ok(createComponent(Pagination, {currentPage: 1, pageSize: 10, total: 30})
+	t.ok(createComponent(Pagination, { currentPage: 1, pageSize: 10, total: 30 })
 			.props.className.indexOf('Pagination') !== -1,
 		'should create .Pagination container');
 
 
-	t.ok(getList({currentPage: 1, pageSize: 10, total: 30})
+	t.ok(getList({ currentPage: 1, pageSize: 10, total: 30 })
 			.props.className.indexOf('Pagination__list') !== -1,
 		'should create .Pagination__list container for pages');
 
 
-	t.equal(getList({currentPage: 1, pageSize: 10, total: 30})
+	t.equal(getList({ currentPage: 1, pageSize: 10, total: 30 })
 			.props.children.length, 3,
 		'should render 3 pages for 30 items with 10 items per page');
 
 
-	t.ok(getList({currentPage: 1, pageSize: 10, total: 30})
+	t.ok(getList({ currentPage: 1, pageSize: 10, total: 30 })
 			.props.children[0].props.className.indexOf('Pagination__list__item') !== -1,
 		'should create .Pagination__list__item containers for each page');
 
 
-	t.ok(getList({currentPage: 2, pageSize: 10, total: 30})
+	t.ok(getList({ currentPage: 2, pageSize: 10, total: 30 })
 			.props.children[1].props.className.indexOf('is-selected') !== -1,
 		'should add "is-selected" class to current page element');
 
 
-	t.deepEqual(getList({currentPage: 1, pageSize: 10, total: 45})
-			.props.children.map(page => page.props.children), [1, 2, 3, 4, 5],
+	t.deepEqual(getList({ currentPage: 1, pageSize: 10, total: 45 })
+		.props.children.map(page => page.props.children), [1, 2, 3, 4, 5],
 		'should render page numbers');
 
 
@@ -55,33 +55,33 @@ test('Pagination. Basics', t => {
 
 test('Pagination. Limit', t => {
 
-	t.deepEqual(getList({currentPage: 1, pageSize: 10, total: 100, limit: 6})
-			.props.children.map(page => page.props.children), [1, 2, 3, 4, 5, 6, 7, '...'],
+	t.deepEqual(getList({ currentPage: 1, pageSize: 10, total: 100, limit: 6 })
+		.props.children.map(page => page.props.children), [1, 2, 3, 4, 5, 6, '...'],
 		'should limit number of first pages when on first page');
 
 
-	t.deepEqual(getList({currentPage: 10, pageSize: 10, total: 100, limit: 6})
-			.props.children.map(page => page.props.children), ['...', 4, 5, 6, 7, 8, 9, 10],
+	t.deepEqual(getList({ currentPage: 10, pageSize: 10, total: 100, limit: 6 })
+		.props.children.map(page => page.props.children), ['...', 5, 6, 7, 8, 9, 10],
 		'should limit number of last pages when on the last page');
 
 
-	t.deepEqual(getList({currentPage: 111, pageSize: 10, total: 105, limit: 6})
-			.props.children.map(page => page.props.children), ['...', 5, 6, 7, 8, 9, 10, 11],
+	t.deepEqual(getList({ currentPage: 111, pageSize: 10, total: 105, limit: 6 })
+		.props.children.map(page => page.props.children), ['...', 6, 7, 8, 9, 10, 11],
 		'should limit number of last pages when on the last page and it is not filled in full');
 
 
-	t.deepEqual(getList({currentPage: 10, pageSize: 25, total: 1000, limit: 5})
-			.props.children.map(page => page.props.children), ['...', 8, 9, 10, 11, 12, '...'],
+	t.deepEqual(getList({ currentPage: 10, pageSize: 25, total: 1000, limit: 5 })
+		.props.children.map(page => page.props.children), ['...', 8, 9, 10, 11, 12, '...'],
 		'should limit number of pages in the middle of pagination (odd number)');
 
 
-	t.deepEqual(getList({currentPage: 10, pageSize: 25, total: 1000, limit: 4})
-			.props.children.map(page => page.props.children), ['...', 8, 9, 10, 11, 12, '...'],
+	t.deepEqual(getList({ currentPage: 10, pageSize: 25, total: 1000, limit: 4 })
+		.props.children.map(page => page.props.children), ['...', 9, 10, 11, 12, '...'],
 		'should limit number of pages in the middle of pagination (even number)');
 
 
-	t.deepEqual(getList({currentPage: 4, pageSize: 36, total: 130, limit: 2})
-			.props.children.map(page => page.props.children), ['...', 2, 3, 4],
+	t.deepEqual(getList({ currentPage: 4, pageSize: 36, total: 130, limit: 2 })
+		.props.children.map(page => page.props.children), ['...', 3, 4],
 		'should render correctly when limit is extremely small');
 
 

--- a/test/components/Pagination-test.js
+++ b/test/components/Pagination-test.js
@@ -1,0 +1,89 @@
+import {test} from 'tape';
+import Pagination from '../../lib/components/Pagination';
+import React from 'react/addons';
+const TestUtils = React.addons.TestUtils;
+
+/**
+ * TODO: move to utils for re-use
+ */
+const createComponent = (component, props, ...children) => {
+	const shallowRenderer = TestUtils.createRenderer();
+	shallowRenderer.render(
+		React.createElement(component, props, children.length === 1 ? children[0] : children)
+	);
+	return shallowRenderer.getRenderOutput();
+};
+
+
+const getList = props => createComponent(Pagination, props).props.children[1];
+
+
+test('Pagination. Basics', t => {
+
+	t.ok(createComponent(Pagination, {currentPage: 1, pageSize: 10, total: 30})
+			.props.className.indexOf('Pagination') !== -1,
+		'should create .Pagination container');
+
+
+	t.ok(getList({currentPage: 1, pageSize: 10, total: 30})
+			.props.className.indexOf('Pagination__list') !== -1,
+		'should create .Pagination__list container for pages');
+
+
+	t.equal(getList({currentPage: 1, pageSize: 10, total: 30})
+			.props.children.length, 3,
+		'should render 3 pages for 30 items with 10 items per page');
+
+
+	t.ok(getList({currentPage: 1, pageSize: 10, total: 30})
+			.props.children[0].props.className.indexOf('Pagination__list__item') !== -1,
+		'should create .Pagination__list__item containers for each page');
+
+
+	t.ok(getList({currentPage: 2, pageSize: 10, total: 30})
+			.props.children[1].props.className.indexOf('is-selected') !== -1,
+		'should add "is-selected" class to current page element');
+
+
+	t.deepEqual(getList({currentPage: 1, pageSize: 10, total: 45})
+			.props.children.map(page => page.props.children), [1, 2, 3, 4, 5],
+		'should render page numbers');
+
+
+	t.end();
+});
+
+test('Pagination. Limit', t => {
+
+	t.deepEqual(getList({currentPage: 1, pageSize: 10, total: 100, limit: 6})
+			.props.children.map(page => page.props.children), [1, 2, 3, 4, 5, 6, 7, '...'],
+		'should limit number of first pages when on first page');
+
+
+	t.deepEqual(getList({currentPage: 10, pageSize: 10, total: 100, limit: 6})
+			.props.children.map(page => page.props.children), ['...', 4, 5, 6, 7, 8, 9, 10],
+		'should limit number of last pages when on the last page');
+
+
+	t.deepEqual(getList({currentPage: 111, pageSize: 10, total: 105, limit: 6})
+			.props.children.map(page => page.props.children), ['...', 5, 6, 7, 8, 9, 10, 11],
+		'should limit number of last pages when on the last page and it is not filled in full');
+
+
+	t.deepEqual(getList({currentPage: 10, pageSize: 25, total: 1000, limit: 5})
+			.props.children.map(page => page.props.children), ['...', 8, 9, 10, 11, 12, '...'],
+		'should limit number of pages in the middle of pagination (odd number)');
+
+
+	t.deepEqual(getList({currentPage: 10, pageSize: 25, total: 1000, limit: 4})
+			.props.children.map(page => page.props.children), ['...', 8, 9, 10, 11, 12, '...'],
+		'should limit number of pages in the middle of pagination (even number)');
+
+
+	t.deepEqual(getList({currentPage: 4, pageSize: 36, total: 130, limit: 2})
+			.props.children.map(page => page.props.children), ['...', 2, 3, 4],
+		'should render correctly when limit is extremely small');
+
+
+	t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,4 @@
+import glob from 'glob';
+
+
+glob.sync('**/*-test.js', {realpath: true, cwd: __dirname}).forEach(require);

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
 import glob from 'glob';
 
 
-glob.sync('**/*-test.js', {realpath: true, cwd: __dirname}).forEach(require);
+glob.sync('**/*-test.js', { realpath: true, cwd: __dirname }).forEach(require);


### PR DESCRIPTION
A #58 spinoff

Works perfectly under Windows.

Tests are super basic with literally zero logic overhead. TAP is common API, supported by pretty much anything. Can add `tap-xunit`, for example, to export CI-friendly XML, and so on.

And it is lightning fast (the only short warm-up overhead added by babel). With node v4 we can step back to `require` and remove babel-node, since it supports most of ES6 syntax.

Coverage report is present too:

![20150922-211745](https://cloud.githubusercontent.com/assets/175264/10017224/f0eebbc0-616f-11e5-849b-587bcef6fca3.png)

![20150922-211833](https://cloud.githubusercontent.com/assets/175264/10017236/fe2f7252-616f-11e5-85de-3de9d777a1b1.png)

Ping @MunGell @JedWatson @zackify