### PR TITLE
React v0.14.0-rc1 and React-Router v1.0.0-rc1 support.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,8 @@ var taskConfig = {
 			'blacklist',
 			'classnames',
 			'react',
-			'react/addons'
+			'react-dom',
+			'react-addons-css-transition-group'
 		],
 		less: {
 			path: 'less',

--- a/package.json
+++ b/package.json
@@ -11,19 +11,22 @@
   },
   "dependencies": {
     "blacklist": "^1.1.2",
-    "classnames": "^2.1.3"
+    "classnames": "^2.1.3",
+    "history": "^1.12.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
     "eslint": "^1.4.3",
     "eslint-plugin-react": "^3.4.1",
     "gulp": "^3.9.0",
-    "react": "^0.13.3",
+    "react": ">=0.14.0-rc1",
+    "react-dom": ">=0.14.0-rc1",
+    "react-addons-css-transition-group": "^0.14.0-rc1",
     "react-component-gulp-tasks": "^0.7.1",
-    "react-router": "^0.13.3"
+    "react-router": "1.0.0-rc1"
   },
   "peerDependencies": {
-    "react": "^0.13.0 || ^0.14.0-beta"
+    "react": "^0.13.0 || 0.14.0-rc1"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/site/src/components/ExampleSource.js
+++ b/site/src/components/ExampleSource.js
@@ -19,7 +19,7 @@ var ExampleSource = React.createClass({
 		this.highlight();
 	},
 	highlight () {
-		Prism.highlightElement(this.refs.code.getDOMNode(), true);
+		Prism.highlightElement(this.refs.code, true);
 	},
 	fixIndentation (children) {
 		if (typeof children !== 'string') return children;

--- a/site/src/pages/CSS.js
+++ b/site/src/pages/CSS.js
@@ -1,6 +1,6 @@
 /* eslint no-script-url: 0 */
 
-const React = require('react/addons');
+const React = require('react');
 const classNames = require('classnames');
 
 const ExampleSource = require('../components/ExampleSource');
@@ -123,7 +123,9 @@ var CSSExamples = React.createClass({
 								<col width="10%" />
 							</colgroup>
 							<thead>
-								{tableHeaderCols}
+								<tr>
+									{tableHeaderCols}
+								</tr>
 							</thead>
 							<tbody>
 								{tableRows}

--- a/site/src/pages/DatePicker.js
+++ b/site/src/pages/DatePicker.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var Button = require('elemental').Button;
 var DateSelect = require('react-date-select');
 

--- a/site/src/pages/Glyphs.js
+++ b/site/src/pages/Glyphs.js
@@ -18,7 +18,7 @@ var Glyphs = React.createClass({
 	displayName: 'VIEW_Glyphs',
 	renderGlyphColorTypes() {
 		return GLYPH_COLOR_TYPES.map(color => {
-			return <span><code className="inline-code">{color}</code>{' '}</span>;
+			return <span key={'color_'+color}><code className="inline-code">{color}</code>{' '}</span>;
 		});
 	},
 	renderGlyphColors(icon) {

--- a/site/src/pages/Grid.js
+++ b/site/src/pages/Grid.js
@@ -1,6 +1,6 @@
 /* eslint no-script-url: 0 */
 
-const React = require('react/addons');
+const React = require('react');
 const { Col, Container, Row, ResponsiveText } = require('elemental');
 
 const DemoBox = require('../components/DemoBox');

--- a/site/src/pages/Modal.js
+++ b/site/src/pages/Modal.js
@@ -1,4 +1,4 @@
-const React = require('react/addons');
+const React = require('react');
 
 const {
 	Button,

--- a/site/src/site.js
+++ b/site/src/site.js
@@ -1,15 +1,17 @@
-var React = require('react');
-var Router = require('react-router');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Router, Route, Link, IndexRoute } from'react-router';
+import { createHistory, useBasename } from 'history';
 
 const NavItems = [
-	{ value: 'css',         label: 'CSS' },
-	{ value: 'grid',        label: 'Grid' },
-	{ value: 'buttons',     label: 'Buttons' },
-	{ value: 'glyphs',      label: 'Glyphs' },
-	{ value: 'forms',       label: 'Forms' },
-	{ value: 'spinner',     label: 'Spinner' },
-	{ value: 'modal',       label: 'Modal' },
-	{ value: 'misc',        label: 'Misc' }
+	{ value: '/css',         label: 'CSS' },
+	{ value: '/grid',        label: 'Grid' },
+	{ value: '/buttons',     label: 'Buttons' },
+	{ value: '/glyphs',      label: 'Glyphs' },
+	{ value: '/forms',       label: 'Forms' },
+	{ value: '/spinner',     label: 'Spinner' },
+	{ value: '/modal',       label: 'Modal' },
+	{ value: '/misc',        label: 'Misc' }
 	// { value: 'date-picker', label: 'Date Picker' }
 ];
 
@@ -49,17 +51,17 @@ var PageNav = React.createClass({
 		var menuClass = this.state.mobileMenuIsVisible ? 'primary-nav-menu is-visible' : 'primary-nav-menu is-hidden';
 		var menuItems = NavItems.map(function(item) {
 			return (
-				<Router.Link key={item.value} className="primary-nav__item" onClick={self.toggleMenu} to={item.value}>
+				<Link key={item.value} className="primary-nav__item" onClick={self.toggleMenu} to={item.value}>
 					<span className="primary-nav__item-inner">{item.label}</span>
-				</Router.Link>
+				</Link>
 			);
 		});
 		return (
 			<nav className="primary-nav">
-				<Router.Link to="home" className="primary-nav__brand special" title="Home">
+				<Link to="/home" className="primary-nav__brand special" title="Home">
 					<img src="./images/elemental-logo-paths.svg" className="primary-nav__brand-src" />
-				</Router.Link>
-				{/*<Router.Link to="home">Home</Router.Link>*/}
+				</Link>
+				{/*<Link to="home">Home</Link>*/}
 				<button onClick={this.toggleMenu} className="primary-nav__item primary-nav-menu-trigger">
 					<span className="primary-nav-menu-trigger-icon octicon octicon-navicon" />
 					<span className="primary-nav-menu-trigger-label">{this.state.mobileMenuIsVisible ? 'Close' : 'Menu'}</span>
@@ -83,7 +85,7 @@ var App = React.createClass({
 			<div className="page-wrapper">
 				<PageNav />
 				<div className="page-body">
-					<Router.RouteHandler/>
+					{this.props.children}
 				</div>
 				<div className="page-footer">
 					<div className="demo-container container">
@@ -98,21 +100,27 @@ var App = React.createClass({
 var basepath = (window.location.pathname.slice(0, 10) === '/elemental') ? '/elemental' : '';
 
 var routes = (
-	<Router.Route name="app" path={basepath + '/'} handler={App}>
-		<Router.Route name="home" path={basepath + '/'} handler={require('./pages/Home')} />
-		<Router.Route name="css" path={basepath + '/css'} handler={require('./pages/CSS')} />
-		<Router.Route name="grid" path={basepath + '/grid'} handler={require('./pages/Grid')} />
-		<Router.Route name="buttons" path={basepath + '/buttons'} handler={require('./pages/Buttons')} />
-		<Router.Route name="glyphs" path={basepath + '/glyphs'} handler={require('./pages/Glyphs')} />
-		<Router.Route name="forms" path={basepath + '/forms'} handler={require('./pages/Forms')} />
-		<Router.Route name="spinner" path={basepath + '/spinner'} handler={require('./pages/Spinner')} />
-		<Router.Route name="modal" path={basepath + '/modal'} handler={require('./pages/Modal')} />
-		<Router.Route name="misc" path={basepath + '/misc'} handler={require('./pages/Misc')} />
-		{/*<Router.Route name="date-picker" path={basepath + '/date-picker'} handler={require('./pages/DatePicker')} />*/}
-		<Router.DefaultRoute handler={require('./pages/Home')} />
-	</Router.Route>
+	<Route path="/" component={App}>
+		<IndexRoute component={require('./pages/Home')} />
+		<Route path="home" component={require('./pages/Home')} />
+		<Route path="css" component={require('./pages/CSS')} />
+		<Route path="grid" component={require('./pages/Grid')} />
+		<Route path="buttons" component={require('./pages/Buttons')} />
+		<Route path="glyphs" component={require('./pages/Glyphs')} />
+		<Route path="forms" component={require('./pages/Forms')} />
+		<Route path="spinner" component={require('./pages/Spinner')} />
+		<Route path="modal" component={require('./pages/Modal')} />
+		<Route path="misc" component={require('./pages/Misc')} />
+		<Route path="*" component={require('./pages/Home')} />
+	</Route>
 );
 
-Router.run(routes, Router.HistoryLocation, function (Handler) {
-	React.render(<Handler/>, document.body);
-});
+//{/*<Router.Route name="date-picker" path={basepath + '/date-picker'} handler={require('./pages/DatePicker')} />*/}
+
+//Router.run(routes, Router.HistoryLocation, function (Handler) {
+//	React.render(<Handler/>, document.body);
+//});
+
+let history = createHistory();
+
+ReactDOM.render(<Router history={history}>{routes}</Router>, document.body);

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 var ALERT_TYPES = [

--- a/src/components/BlankState.js
+++ b/src/components/BlankState.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'BlankState',

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 var blacklist = require('blacklist');
 

--- a/src/components/ButtonGroup.js
+++ b/src/components/ButtonGroup.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ButtonGroup',

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 import E from '../constants';
 
 module.exports = React.createClass({

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classNames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 var Checkbox = React.createClass({
 	propTypes: {
@@ -16,7 +16,7 @@ var Checkbox = React.createClass({
 
 	componentDidMount () {
 		if (this.props.focusOnMount) {
-			this.refs.target.getDOMNode().focus();
+			this.refs.target.focus();
 		}
 		this.setIndeterminate(this.props.indeterminate);
 	},
@@ -26,7 +26,7 @@ var Checkbox = React.createClass({
 	},
 
 	setIndeterminate (value) {
-		this.refs.target.getDOMNode().indeterminate = value;
+		this.refs.target.indeterminate = value;
 	},
 
 	render() {

--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import blacklist from 'blacklist';
 import E from '../constants';
 

--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import blacklist from 'blacklist';
 import E from '../constants';
 

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,5 +1,5 @@
-const React = require('react/addons');
-const ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
+const React = require('react');
+const ReactCSSTransitionGroup = require('react-addons-css-transition-group');
 const blacklist = require('blacklist');
 const classNames = require('classnames');
 const Button = require('./Button');

--- a/src/components/EmailInputGroup.js
+++ b/src/components/EmailInputGroup.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 var REGEXP_EMAIL = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;

--- a/src/components/FileDragAndDrop.js
+++ b/src/components/FileDragAndDrop.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 /*
@@ -60,7 +60,7 @@ var Dropzone = React.createClass({
 	},
 
 	onClick: function () {
-		this.refs.fileInput.getDOMNode().click();
+		this.refs.fileInput.click();
 	},
 
 	render: function() {

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 
 var Button = require('./Button');
@@ -26,12 +26,12 @@ module.exports = React.createClass({
 		};
 	},
         componentDidMount () {
-               this.refs.fileInput.getDOMNode().addEventListener('click', function () {
+               this.refs.fileInput.addEventListener('click', function () {
                        this.value = '';
                },   false);
         },
 	triggerFileBrowser() {
-		this.refs.fileInput.getDOMNode().click();
+		this.refs.fileInput.click();
 	},
 	handleChange(e) {
 		var self = this;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'Form',

--- a/src/components/FormField.js
+++ b/src/components/FormField.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 

--- a/src/components/FormIcon.js
+++ b/src/components/FormIcon.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 var Spinner = require('./Spinner');
 

--- a/src/components/FormIconField.js
+++ b/src/components/FormIconField.js
@@ -1,4 +1,4 @@
-const React = require('react/addons');
+const React = require('react');
 const blacklist = require('blacklist');
 const classNames = require('classnames');
 

--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 
@@ -37,6 +37,7 @@ module.exports = React.createClass({
 	},
 
 	focus() {
+		// If used in the future, will need to import ReactDOM from 'react-dom' to use findDOMNode().
 		// React.findDOMNode(this.refs.target).focus();
 	},
 

--- a/src/components/FormLabel.js
+++ b/src/components/FormLabel.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 

--- a/src/components/FormNote.js
+++ b/src/components/FormNote.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 

--- a/src/components/FormRow.js
+++ b/src/components/FormRow.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -1,6 +1,6 @@
 import blacklist from 'blacklist';
 import classNames from 'classnames';
-import React from 'react/addons';
+import React from 'react';
 import icons from '../icons';
 
 module.exports = React.createClass({

--- a/src/components/Glyph.js
+++ b/src/components/Glyph.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 var icons = require('../Octicons').map;

--- a/src/components/InputGroup.js
+++ b/src/components/InputGroup.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/components/InputGroupSection.js
+++ b/src/components/InputGroupSection.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,8 +1,10 @@
-import React from 'react/addons';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import CSSTransitionGroup from 'react-addons-css-transition-group';
 import blacklist from 'blacklist';
 import classNames from 'classnames';
 
-const Transition = React.addons.CSSTransitionGroup;
+const Transition = CSSTransitionGroup;
 const TransitionPortal = React.createClass({
 	displayName: 'TransitionPortal',
 	portalElement: null,
@@ -17,7 +19,7 @@ const TransitionPortal = React.createClass({
 		document.body.removeChild(this.portalElement);
 	},
 	componentDidUpdate() {
-		React.render(<Transition {...this.props}>{this.props.children}</Transition>, this.portalElement);
+		ReactDOM.render(<Transition {...this.props}>{this.props.children}</Transition>, this.portalElement);
 	}
 });
 

--- a/src/components/ModalBody.js
+++ b/src/components/ModalBody.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ModalBody',

--- a/src/components/ModalFooter.js
+++ b/src/components/ModalFooter.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ModalFooter',

--- a/src/components/ModalHeader.js
+++ b/src/components/ModalHeader.js
@@ -1,5 +1,5 @@
 var classnames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 module.exports = React.createClass({
 	displayName: 'ModalHeader',

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/components/PasswordInputGroup.js
+++ b/src/components/PasswordInputGroup.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 function validatePassword(value) {

--- a/src/components/Pill.js
+++ b/src/components/Pill.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -1,6 +1,6 @@
 var blacklist = require('blacklist');
 var classNames = require('classnames');
-var React = require('react/addons');
+var React = require('react');
 
 var Radio = React.createClass({
 	propTypes: {

--- a/src/components/RadioGroup.js
+++ b/src/components/RadioGroup.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var blacklist = require('blacklist');
 var classNames = require('classnames');
 

--- a/src/components/ResponsiveText.js
+++ b/src/components/ResponsiveText.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import blacklist from 'blacklist';
 import E from '../constants';
 

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
 import E from '../constants';

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -1,4 +1,4 @@
-var React = require('react/addons');
+var React = require('react');
 var classNames = require('classnames');
 
 module.exports = React.createClass({

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,5 +1,5 @@
 import classNames from'classnames';
-import React from'react/addons';
+import React from'react';
 
 module.exports = React.createClass({
 	displayName: 'Table',


### PR DESCRIPTION
Gets rid of all react 0.14 and react-router 1.0 release candidate warnings.

EXCEPTION: ReactCSSTransitionGroup is only warning I'm finding right now. Looks like it has to do with dropdown animation or something.