### PR TITLE
Updating packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,18 +11,18 @@
   },
   "dependencies": {
     "blacklist": "^1.1.2",
-    "classnames": "^2.1.3",
+    "classnames": "^2.1.5",
     "history": "^1.12.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
-    "eslint": "^1.4.3",
-    "eslint-plugin-react": "^3.4.1",
+    "eslint": "^1.6.0",
+    "eslint-plugin-react": "^3.5.1",
     "gulp": "^3.9.0",
     "react": ">=0.14.0-rc1",
     "react-dom": ">=0.14.0-rc1",
     "react-addons-css-transition-group": "^0.14.0-rc1",
-    "react-component-gulp-tasks": "^0.7.1",
+    "react-component-gulp-tasks": "^0.7.6",
     "react-router": "1.0.0-rc1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updating packages to keep react 14 branch up to date with master. Also using 1.7.6 instead of 1.7.5 for react-component-gulp-tasks