### PR TITLE
Bower support, fixes #39

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@ src
 gulpfile.js
 npm-debug.log
 package.json
+/scripts/
+/bower.json

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "elemental",
+  "version": "0.0.0",
+  "description": "React UI Framework",
+  "main": "elemental.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elementalui/elemental-dist.git"
+  },
+  "dependencies": {
+    "react": "^0.14"
+  },
+  "keywords": [
+    "react",
+    "react-component",
+    "ui",
+    "framework",
+    "controls",
+    "element",
+    "css",
+    "less"
+  ],
+  "authors": [
+    "Jed Watson"
+  ],
+  "homepage": "http://elemental-ui.com",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "publish:npm": "gulp publish:npm",
     "publish:site": "gulp publish:examples",
     "publish:tag": "gulp publish:tag",
+    "publish:bower": "./scripts/bower.sh",
     "release": "gulp release",
     "site": "gulp dev:server",
     "start": "gulp dev",

--- a/scripts/bower.sh
+++ b/scripts/bower.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+ORG="elementalui"
+NAME=$(echo 'console.log(require("./package.json").name)' | node)
+REPO="$NAME-dist"
+VERSION=$(echo 'console.log(require("./package.json").version)' | node)
+
+echo ORG=$ORG
+echo NAME=$NAME
+echo REPO=$REPO
+echo VERSION=$VERSION
+
+pushd .
+rm -rf /tmp/$ORG/$REPO
+mkdir -p /tmp/$ORG/$REPO
+git clone git@github.com:$ORG/$REPO.git /tmp/$ORG/$REPO
+npm run build
+cp -f ./dist/* /tmp/$ORG/$REPO
+cp -f ./bower.json /tmp/$ORG/$REPO
+cd /tmp/$ORG/$REPO
+git add .
+git commit -m "Release $VERSION"
+bower version $VERSION
+git push && git push --tags
+popd


### PR DESCRIPTION
Script for automatic publishing to Bower.

For now OSX/Linux only

To test, I checked out `v0.5.1` tag, applied patch with these changes and run script.

<img width="652" alt="20151021-000051" src="https://cloud.githubusercontent.com/assets/175264/10607804/ceba5b30-7787-11e5-9e95-8f7c2f2bc14f.png">
<img width="483" alt="20151021-000114" src="https://cloud.githubusercontent.com/assets/175264/10607803/ceb2666e-7787-11e5-837f-688b9d31633f.png">
