### PR TITLE
Fix server rendering of elemental components

### DIFF
--- a/src/components/Col.js
+++ b/src/components/Col.js
@@ -26,18 +26,18 @@ module.exports = React.createClass({
 	},
 	getInitialState: function() {
 		return {
-			windowWidth: window.innerWidth
+			windowWidth: (typeof window !== 'undefined') ? window.innerWidth : 0
 		};
 	},
 	componentDidMount: function() {
-		window.addEventListener('resize', this.handleResize);
+		if (typeof window !== 'undefined') window.addEventListener('resize', this.handleResize);
 	},
 	componentWillUnmount: function() {
-		window.removeEventListener('resize', this.handleResize);
+		if (typeof window !== 'undefined') window.removeEventListener('resize', this.handleResize);
 	},
 	handleResize: function() {
 		this.setState({
-			windowWidth: window.innerWidth
+			windowWidth: (typeof window !== 'undefined') ? window.innerWidth : 0
 		});
 	},
 	render() {

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -37,6 +37,7 @@ module.exports = React.createClass({
 		this.setState({ isOpen: false });
 	},
 	componentWillUpdate (nextProps, nextState) {
+		if (typeof window === 'undefined') return;		
 		if (nextState.isOpen) {
 			window.addEventListener('keydown', this.handleKeyDown);
 		} else {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -41,10 +41,10 @@ module.exports = React.createClass({
 	},
 	componentWillReceiveProps: function(nextProps) {
 		if (nextProps.isOpen) {
-			window.addEventListener('keydown', this.handleKeyDown);
+			if (typeof window !== 'undefined') window.addEventListener('keydown', this.handleKeyDown);
 			document.body.style.overflow = 'hidden';
 		} else {
-			window.removeEventListener('keydown', this.handleKeyDown);
+			if (typeof window !== 'undefined') window.removeEventListener('keydown', this.handleKeyDown);
 			document.body.style.overflow = null;
 		}
 	},

--- a/src/components/ResponsiveText.js
+++ b/src/components/ResponsiveText.js
@@ -16,18 +16,18 @@ module.exports = React.createClass({
 	},
 	getInitialState: function() {
 		return {
-			windowWidth: window.innerWidth
+			windowWidth: (typeof window !== 'undefined') ? window.innerWidth : 0
 		};
 	},
 	componentDidMount: function() {
-		window.addEventListener('resize', this.handleResize);
+		if (typeof window !== 'undefined') window.addEventListener('resize', this.handleResize);
 	},
 	componentWillUnmount: function() {
-		window.removeEventListener('resize', this.handleResize);
+		if (typeof window !== 'undefined') window.removeEventListener('resize', this.handleResize);
 	},
 	handleResize: function() {
 		this.setState({
-			windowWidth: window.innerWidth
+			windowWidth: (typeof window !== 'undefined') ? window.innerWidth : 0
 		});
 	},
 	render() {


### PR DESCRIPTION
Components are able to render on server, but React still had to compensate style differences, that's unfortunate drawback of flexible grid system.

```
Warning: React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server:
 (client) ng-right:10px;width:33.33333333333333%;"
 (server) ng-right:10px;width:100%;" data-reactid=
```
