### PR TITLE
Use react autoFocus property to set focus for inputs

### DIFF
--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -128,7 +128,7 @@ var Forms = React.createClass({
 					<div className="code-example__example">
 						<Form>
 							<FormField label="Email address" htmlFor="basic-form-input-email">
-								<FormInput autofocus type="email" placeholder="Enter email" name="basic-form-input-email" />
+								<FormInput autoFocus type="email" placeholder="Enter email" name="basic-form-input-email" />
 							</FormField>
 							<FormField label="Password" htmlFor="basic-form-input-password">
 								<FormInput type="password" placeholder="Password" name="basic-form-input-password" />
@@ -143,7 +143,7 @@ var Forms = React.createClass({
 						{`
 							<Form>
 								<FormField label="Email address" htmlFor="basic-form-input-email">
-									<FormInput autofocus type="email" placeholder="Enter email" name="basic-form-input-email" />
+									<FormInput autoFocus type="email" placeholder="Enter email" name="basic-form-input-email" />
 								</FormField>
 								<FormField label="Password" htmlFor="basic-form-input-password">
 									<FormInput type="password" placeholder="Password" name="basic-form-input-password" />

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -6,7 +6,7 @@ const Checkbox = React.createClass({
 	propTypes: {
 		className: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
-		autofocus: React.PropTypes.bool,
+		autoFocus: React.PropTypes.bool,
 		indeterminate: React.PropTypes.bool,
 		inline: React.PropTypes.bool,
 		label: React.PropTypes.string,
@@ -15,9 +15,6 @@ const Checkbox = React.createClass({
 	},
 
 	componentDidMount () {
-		if (this.props.autofocus) {
-			this.refs.target.focus();
-		}
 		this.setIndeterminate(this.props.indeterminate);
 	},
 

--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -5,7 +5,7 @@ var classNames = require('classnames');
 module.exports = React.createClass({
 	displayName: 'FormInput',
 	propTypes: {
-		autofocus: React.PropTypes.bool,
+		autoFocus: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
 		href: React.PropTypes.string,
@@ -28,16 +28,6 @@ module.exports = React.createClass({
 		};
 	},
 
-	componentDidMount () {
-		if (this.props.autofocus) {
-			this.focus();
-		}
-	},
-
-	focus() {
-		this.refs.input.focus();
-	},
-
 	render() {
 		// classes
 		let className = classNames(
@@ -49,7 +39,7 @@ module.exports = React.createClass({
 			(this.props.size ? ('FormInput--' + this.props.size) : null),
 			this.props.className
 		);
-		let props = { ...this.props, className, ref: 'input' };
+		let props = { ...this.props, className };
 		let Element = 'input';
 		if (this.props.noedit && this.props.href) {
 			Element = 'a';


### PR DESCRIPTION
Uses React ```autoFocus``` property instead of calling ```.focus()```
Related to #94 
