### PR TITLE
Accessibility fixes for the `Modal` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/elementalui/elemental.git"
   },
   "dependencies": {
+    "ally.js": "^1.0.1",
     "blacklist": "^1.1.2",
     "classnames": "^2.2.0"
   },

--- a/site/src/pages/Modal.js
+++ b/site/src/pages/Modal.js
@@ -20,6 +20,7 @@ module.exports = React.createClass({
 	getInitialState() {
 		return {
 			modalIsOpen: false,
+			sizedModalIsOpen: false,
 		};
 	},
 	toggleModal(visible) {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -45,7 +45,6 @@ module.exports = React.createClass({
 			setTimeout(() => this.handleAccessibility());
 			document.body.style.overflow = 'hidden';
 		} else {
-			document.body.style.overflow = null;
 			setTimeout(() => this.removeAccessibilityHandlers());
 		}
 	},
@@ -92,7 +91,7 @@ module.exports = React.createClass({
 
 		// React to escape keys as mandated by ARIA Practices
 		this.keyHandle = ally.when.key({
-			escape: this.props.onCancel,
+			escape: this.handleClose,
 		});
 	},
 	removeAccessibilityHandlers () {
@@ -109,7 +108,11 @@ module.exports = React.createClass({
 		this.focusedElementBeforeModalOpened && this.focusedElementBeforeModalOpened.focus();
 	},
 	handleModalClick (event) {
-		if (event.target.dataset.modal) this.props.onCancel();
+		if (event.target.dataset.modal) this.handleClose();
+	},
+	handleClose () {
+		document.body.style.overflow = null;
+		this.props.onCancel();
 	},
 	renderDialog() {
 		if (!this.props.isOpen) return;
@@ -129,7 +132,7 @@ module.exports = React.createClass({
 	renderBackdrop() {
 		if (!this.props.isOpen) return;
 
-		return <div className="Modal-backdrop" onClick={this.props.backdropClosesModal ? this.props.onCancel : null} />;
+		return <div className="Modal-backdrop" onClick={this.props.backdropClosesModal ? this.handleClose : null} />;
 	},
 	render() {
 		var className = classNames('Modal', {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -45,11 +45,10 @@ module.exports = React.createClass({
 			setTimeout(() => this.handleAccessibility());
 			document.body.style.overflow = 'hidden';
 		} else {
-			setTimeout(() => this.removeAccessibilityHandles());
 			document.body.style.overflow = null;
+			setTimeout(() => this.removeAccessibilityHandlers());
 		}
 	},
-
 	handleAccessibility () {
 		// Remember the element that was focused before we opened the modal
 		// so we can return focus to it once we close the modal.
@@ -96,8 +95,7 @@ module.exports = React.createClass({
 			escape: this.props.onCancel,
 		});
 	},
-
-	removeAccessibilityHandles () {
+	removeAccessibilityHandlers () {
 		// undo listening to keyboard
 		this.keyHandle && this.keyHandle.disengage();
 
@@ -110,7 +108,6 @@ module.exports = React.createClass({
 		// return focus to where it was before we opened the modal
 		this.focusedElementBeforeModalOpened && this.focusedElementBeforeModalOpened.focus();
 	},
-
 	handleModalClick (event) {
 		if (event.target.dataset.modal) this.props.onCancel();
 	},

--- a/src/components/ModalHeader.js
+++ b/src/components/ModalHeader.js
@@ -10,11 +10,15 @@ module.exports = React.createClass({
 		showCloseButton: React.PropTypes.bool,
 		text: React.PropTypes.string
 	},
+	handleClose () {
+		document.body.style.overflow = null;
+		this.props.onClose();
+	},
 	render() {
 
 		// elements
 		var className = classnames('Modal__header', this.props.className);
-		var close = this.props.showCloseButton ? <button type="button" onClick={this.props.onClose} className="Modal__header__close" /> : null;
+		var close = this.props.showCloseButton ? <button type="button" onClick={this.handleClose} className="Modal__header__close" /> : null;
 		var text = this.props.text ? <h4 className="Modal__header__text">{this.props.text}</h4> : null;
 		return (
 			<div {...this.props} className={className}>


### PR DESCRIPTION
This PR fixes a couple of accessibility issues in the `Modal` component, by using the [`ally.js`](https://github.com/medialize/ally.js) package.

* Make sure no element outside of the modal can be focused (by any means, including keyboard and mouse)
* Focus the first keyboard focusable (tabbable) element in the modal upon opening the modal, or focus the modal itself, if it doesn't contain any focusable elements
* Focus the element that had focus before the modal was shown upon closing the modal
* Make sure no element outside of the modal is visible to screen readers (analog to how we obfuscate the content visually by way of the backdrop)
* Make sure to transfer focus to the modal only when the modal is visible, to avoid the document from being scrolled by the browser