### PR TITLE
Remove autofocusing in the modal

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -53,28 +53,6 @@ module.exports = React.createClass({
 		// so we can return focus to it once we close the modal.
 		this.focusedElementBeforeModalOpened = document.activeElement;
 
-		// We're using a transition to reveal the modal,
-		// so wait until the element is visible, before
-		// finding the first keyboard focusable element
-		// and passing focus to it, otherwise the browser
-		// might scroll the document to reveal the element
-		// receiving focus
-		ally.when.visibleArea({
-			context: this.modalElement,
-			callback: function(context) {
-				// the modal is visible on screen, so find the first
-				// keyboard focusable element (giving any element with
-				// autofocus attribute precendence). If the modal does
-				// not contain any keyboard focusabe elements, focus will
-				// be given to the modal itself.
-				var element = ally.query.firstTabbable({
-					context: context,
-					defaultToContext: true,
-				});
-				element.focus();
-			},
-		});
-
 		// Make sure that no element outside of the modal
 		// can be interacted with while the modal is visible.
 		this.disabledHandle = ally.maintain.disabled({


### PR DESCRIPTION
Remove autofocusing on the first focusable element in the modal as this is not compatible with React’s way of handling autofocus. React doesn’t add the `autoFocus` prop to DOM elements which `ally.js` is dependent on.

Reference: https://github.com/facebook/react/issues/3066#issuecomment-73305996