### PR TITLE
[WIP] Classnames exports window.classNames and not window.classnames, fixes #85

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var taskConfig = {
 		lib: 'lib',
 		dependencies: [
 			'blacklist',
-			'classnames',
+			'classNames',
 			'history',
 			'react',
 			'react-addons-css-transition-group',


### PR DESCRIPTION
Checked with this file:

```
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Title</title>
	<link rel="stylesheet" href="./dist/elemental.css">
</head>
<body>

Hello!

<script src="https://npmcdn.com/react@0.14.3/dist/react.min.js"></script>
<script src="https://npmcdn.com/react-dom@0.14.3/dist/react-dom.min.js"></script>
<script src="https://npmcdn.com/classnames@2.2.1"></script>
<script src="https://npmcdn.com/blacklist@1.1.2"></script>
<script src="./dist/elemental.js"></script>
</body>
</html>
```

Does not throw an exception. Though I need to check a bit more if it actually works fine.

The only problem left - `blacklist`. It does not have UMD wrapper. I'll PR there.

