### PR TITLE
use '1' for '100%' in Col constants when using fractions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -61,7 +61,9 @@ function denominators (n) {
 	}
 }
 
-exports.fractions = {};
+exports.fractions = {
+	"1": "100%"
+};
 
 for (var numerator = 1; numerator <= 19; numerator++) {
 	denominators(numerator);


### PR DESCRIPTION
When using fractions in the Col component it is intuitive to use '1' to mean '100%'.