### PR TITLE
Hotfix/add on change callback

### DIFF
--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -51,7 +51,7 @@ module.exports = React.createClass({
 				dataURI: upload.target.result
 			});
 			if (typeof this.props.onChange === 'function') {
-				this.props.onChange({
+				this.props.onChange(e, {
 					file: file,
 					dataURI: upload.target.result
 				});

--- a/src/components/FileUpload.js
+++ b/src/components/FileUpload.js
@@ -48,8 +48,14 @@ module.exports = React.createClass({
 			this.setState({
 				loading: false,
 				file: file,
-				dataURI: upload.target.result,
+				dataURI: upload.target.result
 			});
+			if (typeof this.props.onChange === 'function') {
+				this.props.onChange({
+					file: file,
+					dataURI: upload.target.result
+				});
+			}
 		};
 	},
 	cancelUpload () {


### PR DESCRIPTION
I wasn't sure how to get access to the file, so I added a call to onChange that would be passed via props. It's currently blacklisted on the file input's props. With this you get access to the event, file, and dataURI.
- Calls a `this.props.onChange(e, newFileState)`