### PR TITLE
Add autoComplete property for FormInput

### DIFF
--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -6,6 +6,7 @@ module.exports = React.createClass({
 	displayName: 'FormInput',
 	propTypes: {
 		autofocus: React.PropTypes.bool,
+		autoComplete: React.PropTypes.string,
 		className: React.PropTypes.string,
 		disabled: React.PropTypes.bool,
 		href: React.PropTypes.string,
@@ -25,6 +26,7 @@ module.exports = React.createClass({
 	getDefaultProps() {
 		return {
 			type: 'text',
+			autoComplete: 'off'
 		};
 	},
 


### PR DESCRIPTION
Most of times an input does not need autocomplete to be enabled, or it's just annoying. i.e. when using a dropdown with an input (as an input suggestion component), the autocomplete popup box by the browser covers that dropdown. And it's very necessary to enable/disable autocomplete for web accessibility. 

It looks like this

```jsx
<FormInput type="text" /> // autocomplete disabled
<FormInput type="text" autoComplete/> // autocomplete enabled
```

Or set it with on/off:
```jsx
<FormInput type="text" autoComplete="off" /> // disabled
<FormInput type="text" autoComplete="on"/> // enabled
```

:)