### PR TITLE
Keep Table class when specifying className

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -18,7 +18,7 @@ module.exports = React.createClass({
 
 		// render table element
 		return (
-			<table className={className} {...this.props} />
+			<table {...this.props} className={className} />
 		);
 	}
 });


### PR DESCRIPTION
Fixes #133

This PR moves `className` so that it takes precedence over the `props` spread.  We could use blacklist here instead, but other components seem to solve the same problem in this way.