### PR TITLE
fix for page_start pagination button

### DIFF
--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -90,7 +90,7 @@ module.exports = React.createClass({
 			}
 		}
 		if (minPage > 1) {
-			pages.push(<Page key="page_start" onSelect={this.onPageSelect}>...</Page>);
+			pages.push(<Page key="page_start" onSelect={this.onPageSelect} page={1}>...</Page>);
 		}
 		for (let page = minPage; page <= maxPage; page++) {
 			let selected = (page === currentPage);


### PR DESCRIPTION
see example at http://elemental-ui.com/misc, change the total nr of records to 200, click the right ellipsis, then click the left ellipsis, `currentPage` becomes undefined.