### PR TITLE
Add "text" octicons for bold, italic and text-size

### DIFF
--- a/less/base/octicons.less
+++ b/less/base/octicons.less
@@ -39,6 +39,7 @@
 .octicon-microscope:before,
 .octicon-beaker:before { content: '\f0dd'} /*  */
 .octicon-bell:before { content: '\f0de'} /*  */
+.octicon-bold:before { content: 'B'; font-weight: bolder; }
 .octicon-book:before { content: '\f007'} /*  */
 .octicon-bookmark:before { content: '\f07b'} /*  */
 .octicon-briefcase:before { content: '\f0d3'} /*  */
@@ -119,6 +120,7 @@
 .octicon-issue-closed:before { content: '\f028'} /*  */
 .octicon-issue-opened:before { content: '\f026'} /*  */
 .octicon-issue-reopened:before { content: '\f027'} /*  */
+.octicon-italic:before { content: 'I'; font-weight: bolder; font-style: italic; }
 .octicon-jersey:before { content: '\f019'} /*  */
 .octicon-key:before { content: '\f049'} /*  */
 .octicon-keyboard:before { content: '\f00d'} /*  */
@@ -202,6 +204,7 @@
 .octicon-tag:before { content: '\f015'} /*  */
 .octicon-telescope:before { content: '\f088'} /*  */
 .octicon-terminal:before { content: '\f0c8'} /*  */
+.octicon-text-size:before { content: 'H'; font-weight: bolder; }
 .octicon-three-bars:before { content: '\f05e'} /*  */
 .octicon-thumbsdown:before { content: '\f0db'} /*  */
 .octicon-thumbsup:before { content: '\f0da'} /*  */


### PR DESCRIPTION
As pointed in https://github.com/elementalui/elemental/pull/146 updating octicons version to 3.5.0 is not wanted right now. So this is is a little ttrick to have bold, italic and text-size "octicon styles" so boostrap-markdown can use them just fine