### PR TITLE
Allow invalidation via props instead of internal state

### DIFF
--- a/src/components/EmailInputGroup.js
+++ b/src/components/EmailInputGroup.js
@@ -13,6 +13,7 @@ module.exports = React.createClass({
 		alwaysValidate: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		invalidMessage: React.PropTypes.string,
+		isValid: React.PropTypes.bool,
 		label: React.PropTypes.string,
 		onChange: React.PropTypes.func,
 		required: React.PropTypes.bool,

--- a/src/components/EmailInputGroup.js
+++ b/src/components/EmailInputGroup.js
@@ -72,7 +72,7 @@ module.exports = React.createClass({
 	},
 	render () {
 		var validationMessage;
-		if (!this.state.isValid) {
+		if (!this.state.isValid || !this.props.isValid) {
 			validationMessage = (
 				<div className="form-validation is-invalid">
 					{this.props.value.length ? this.props.invalidMessage : this.props.requiredMessage}
@@ -80,7 +80,7 @@ module.exports = React.createClass({
 			);
 		}
 		var formGroupClass = classNames('FormField', {
-			'is-invalid': !this.state.isValid,
+			'is-invalid': !this.state.isValid || !this.props.isValid,
 		}, this.props.className);
 
 		var componentLabel = this.props.label ? <label className="FormLabel" htmlFor="inputEmail">{this.props.label}</label> : null;

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -89,12 +89,12 @@ module.exports = React.createClass({
 
 		// classes
 		let componentClass = classNames('FormField', {
-			'is-invalid': !this.state.isValid,
+			'is-invalid': !this.state.isValid || !this.props.isValid,
 		}, this.props.className);
 
 		// validation message
 		let validationMessage;
-		if (!this.state.isValid) {
+		if (!this.state.isValid || !this.props.isValid) {
 			validationMessage = (
 				<div className="form-validation is-invalid">{this.props.requiredMessage}</div>
 			);

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -12,6 +12,7 @@ module.exports = React.createClass({
 		firstOption: React.PropTypes.string,
 		htmlFor: React.PropTypes.string,
 		id: React.PropTypes.string,
+		isValid: React.PropTypes.bool,
 		label: React.PropTypes.string,
 		onChange: React.PropTypes.func.isRequired,
 		options: React.PropTypes.arrayOf(

--- a/src/components/PasswordInputGroup.js
+++ b/src/components/PasswordInputGroup.js
@@ -11,6 +11,7 @@ module.exports = React.createClass({
 		alwaysValidate: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		invalidMessage: React.PropTypes.string,
+		isValid: React.PropTypes.bool,
 		label: React.PropTypes.string,
 		onChange: React.PropTypes.func,
 		required: React.PropTypes.bool,

--- a/src/components/PasswordInputGroup.js
+++ b/src/components/PasswordInputGroup.js
@@ -72,7 +72,7 @@ module.exports = React.createClass({
 	},
 	render() {
 		var validationMessage;
-		if (!this.state.isValid) {
+		if (!this.state.isValid || !this.props.isValid) {
 			validationMessage = (
 				<div className="form-validation is-invalid">
 					{this.props.value.length ? this.props.invalidMessage : this.props.requiredMessage}
@@ -80,7 +80,7 @@ module.exports = React.createClass({
 			);
 		}
 		var formGroupClass = classNames('FormField', {
-			'is-invalid': !this.state.isValid
+			'is-invalid': !this.state.isValid || !this.props.isValid,
 		}, this.props.className);
 
 		var componentLabel = this.props.label ? <label className="FormLabel" htmlFor="inputPassword">{this.props.label}</label> : null;

--- a/src/components/RadioGroup.js
+++ b/src/components/RadioGroup.js
@@ -8,6 +8,7 @@ module.exports = React.createClass({
 		alwaysValidate: React.PropTypes.bool,
 		className: React.PropTypes.string,
 		inline: React.PropTypes.bool,
+		isValid: React.PropTypes.bool,
 		label: React.PropTypes.string,
 		onChange: React.PropTypes.func.isRequired,
 		options: React.PropTypes.array.isRequired,

--- a/src/components/RadioGroup.js
+++ b/src/components/RadioGroup.js
@@ -73,12 +73,12 @@ module.exports = React.createClass({
 
 		// classes
 		var componentClass = classNames('FormField', {
-			'is-invalid': !this.state.isValid
+			'is-invalid': !this.state.isValid || !this.props.isValid,
 		}, this.props.className);
 
 		// validation message
 		var validationMessage;
-		if (!this.state.isValid) {
+		if (!this.state.isValid || !this.props.isValid) {
 			validationMessage = (
 				<div className="form-validation is-invalid">{this.props.requiredMessage}</div>
 			);


### PR DESCRIPTION
This is needed to allow Keystone to display server-side validation errors inline, ref https://github.com/keystonejs/keystone/pull/2566