### PR TITLE
Theming with first Alert theme implementation.

### DIFF
--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -1,13 +1,13 @@
 var React = require('react');
 var classNames = require('classnames');
+var utils = require('../utils');
 
 var ALERT_TYPES = [
 	'danger',
 	'error', // alias for danger
 	'info',
-	'primary',
 	'success',
-	'warning',
+	'warning'
 ];
 
 module.exports = React.createClass({
@@ -15,12 +15,27 @@ module.exports = React.createClass({
 	propTypes: {
 		children: React.PropTypes.node.isRequired,
 		className: React.PropTypes.string,
-		type: React.PropTypes.oneOf(ALERT_TYPES).isRequired,
+		theme: utils.getThemeValidator({
+			classes: ALERT_TYPES
+		}),
+		type: React.PropTypes.oneOf(ALERT_TYPES).isRequired
+	},
+	getDefaultProps () {
+		return {
+			theme: {
+				classes: {
+					danger: 'Alert Alert--danger',
+					error: 'Alert Alert--danger',
+					info: 'Alert Alert--info',
+					success: 'Alert Alert--success',
+					warning: 'Alert Alert--warning'
+				}
+			}
+		};
 	},
 	render () {
 		var componentClass = classNames(
-			'Alert',
-			'Alert--' + this.props.type,
+			this.props.theme.classes[this.props.type],
 			this.props.className
 		);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,37 @@
+exports.getThemeValidator = function(options) {
+	function msg(propName, componentName) {
+		return 'Invalid prop `' + propName + '` supplied to' +
+			' `' + componentName + '`. Validation failed.';
+	}
+
+	return function(props, propName, componentName) {
+		if (propName !== 'theme') return;
+
+		// Missing the theme object.
+		if (typeof props.theme !== 'object') {
+			return new Error(msg('theme', componentName));
+		}
+
+		if (options.classes) {
+			// Missing classes object.
+			if (typeof props.theme.classes !== 'object') {
+				return new Error(msg('theme.classes', componentName));
+			}
+
+			// Missing specific classes.
+			for (var i = 0; i < options.classes.length; i++) {
+				var name = options.classes[i];
+				if (typeof props.theme.classes[name] !== 'string') {
+					return new Error(msg('theme.classes.' + name, componentName));
+				}
+			}
+
+			// Unknown class in the theme.
+			for (var name in props.theme.classes) {
+				if (options.classes.indexOf(name) === -1) {
+					return new Error(msg('theme.classes.' + name, componentName));
+				}
+			}
+		}
+	};
+};


### PR DESCRIPTION
This is a follow up  on #53 

I was hesitating with jss integration because of a number of unsolved problems. In fact it's not elemental specific problems, it's those of the entire react ecosystem.
1. There is no standard, widely adopted way for making components themeable.
2. Components should have a default theme, but it **have to be** be optional.
3. Lib Components **need** to stay agnostic towards CSS preprocessors and CSS rendering libraries.

To allow all this, I have **started** to work on a [theme-standard](https://github.com/kof/theme-standard)

As any standard, it needs to get a real life proof and learn from real projects.

This PR is an attempt to implement ideas from this standard and produce a proof of concept for it.

For the Elemental library this will be the first step in this direction, the next steps are:
1. Rewrite less in jss, to get rid of class names collisions and build tools.
2. Separate system styles from theme styles, this will make theme styles more robust.
3. Remove default team from the elemental repository.
