### PR TITLE
Strip non-<input> props

### DIFF
--- a/src/components/FormInput.js
+++ b/src/components/FormInput.js
@@ -39,27 +39,28 @@ module.exports = React.createClass({
 	},
 
 	render() {
+		const {noedit, multiline, size, className, autofocus, ...rest} = this.props;
 		// classes
 		let className = classNames(
 			{
-				'FormInput-noedit': this.props.noedit,
-				'FormInput-noedit--multiline': this.props.noedit && this.props.multiline,
-				'FormInput': !this.props.noedit,
+				'FormInput-noedit': noedit,
+				'FormInput-noedit--multiline': noedit && multiline,
+				'FormInput': !noedit,
 			},
-			(this.props.size ? ('FormInput--' + this.props.size) : null),
-			this.props.className
+			(size ? ('FormInput--' + size) : null),
+			className
 		);
-		let props = { ...this.props, className, ref: 'input' };
+		let props = { ...rest, className, ref: 'input' };
 		let Element = 'input';
-		if (this.props.noedit && this.props.href) {
+		if (noedit && this.props.href) {
 			Element = 'a';
 			props.type = null;
 			props.children = props.children || props.value;
-		} else if (this.props.noedit) {
+		} else if (noedit) {
 			Element = 'div';
 			props.type = null;
 			props.children = props.children || props.value;
-		} else if (this.props.multiline) {
+		} else if (multiline) {
 			Element = 'textarea';
 		}
 


### PR DESCRIPTION
This gets rid of the warning in React 15.2+

Note that `autofocus` needs stripping too, but if you implement #165 this is not necessary.