### PR TITLE
Add 'disabled' prop to options for FormSelect

### DIFF
--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -30,7 +30,7 @@ const controlOptions = [
 	{ label: 'Caramel',    value: 'caramel' },
 	{ label: 'Chocolate',  value: 'chocolate' },
 	{ label: 'Strawberry', value: 'strawberry' },
-	{ label: 'Vanilla',    value: 'vanilla' }
+	{ label: 'Vanilla',    value: 'vanilla', disabled: true }
 ];
 const COUNTRIES = require('../data/countries');
 const COLOR_VARIANTS = [

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -18,6 +18,7 @@ module.exports = React.createClass({
 			React.PropTypes.shape({
 				label: React.PropTypes.string,
 				value: React.PropTypes.string,
+				disabled: React.PropTypes.bool,
 			})
 		).isRequired,
 		prependEmptyOption: React.PropTypes.bool,
@@ -106,7 +107,7 @@ module.exports = React.createClass({
 
 		// options
 		let options = this.props.options.map(function(opt, i) {
-			return <option key={'option-' + i} value={opt.value}>{opt.label}</option>;
+			return <option key={'option-' + i} value={opt.value} disabled={opt.disabled}>{opt.label}</option>;
 		});
 		if (this.props.prependEmptyOption || this.props.firstOption) {
 			options.unshift(


### PR DESCRIPTION
This fix adds `disabled` prop to options of `<FormSelect>` component, which is mentioned in #177 .
I didn't include updates for the documentation. Because I feel that the example code of `<FormSelect>` is not enough to me. It doesn't show a shape of `options` prop.

```
<FormSelect options={[...]} firstOption="Select" onChange={this.handleSelect} />
```

How about following example code? It's somewhat ugly but I have no idea to show this.
Please let me know your comment 😃 

```
const controlOptions = [
	{ label: 'Caramel',    value: 'caramel' },
	{ label: 'Chocolate',  value: 'chocolate' },
	{ label: 'Strawberry', value: 'strawberry' },
	{ label: 'Vanilla',    value: 'vanilla', disabled: true }
];

// ...

<FormSelect options={controlOptions} firstOption="Select" onChange={this.handleSelect} />
```