### PR TITLE
Add new prop "label" to customize pagination's labels

### DIFF
--- a/site/src/pages/Misc.js
+++ b/site/src/pages/Misc.js
@@ -54,17 +54,17 @@ var Misc = React.createClass({
 
 	render() {
 		const labelFn = params => {
-      let count = '';
+			let count = '';
 			const { currentPage, pageSize, total } = params;
-      if (!total) {
-        count = '表示する項目がありません';
-      } else if (total > pageSize) {
-        const { start, end } = params;
-        count = total + ' 件中 ' + start + ' から ' + end + ' まで表示';
-      } else {
-        count = '全 ' + total + ' 件を表示';
-      }
-      return count;
+			if (!total) {
+				count = '表示する項目がありません';
+			} else if (total > pageSize) {
+				const { start, end } = params;
+				count = total + ' 件中 ' + start + ' から ' + end + ' まで表示';
+			} else {
+				count = '全 ' + total + ' 件を表示';
+			}
+			return count;
 		};
 
 		return (

--- a/site/src/pages/Misc.js
+++ b/site/src/pages/Misc.js
@@ -53,6 +53,20 @@ var Misc = React.createClass({
 	},
 
 	render() {
+		const labelFn = params => {
+      let count = '';
+			const { currentPage, pageSize, total } = params;
+      if (!total) {
+        count = '表示する項目がありません';
+      } else if (total > pageSize) {
+        const { start, end } = params;
+        count = total + ' 件中 ' + start + ' から ' + end + ' まで表示';
+      } else {
+        count = '全 ' + total + ' 件を表示';
+      }
+      return count;
+		};
+
 		return (
 			<Container maxWidth={800} className="demo-container">
 				<h1>Miscellaneous</h1>
@@ -278,8 +292,55 @@ var Misc = React.createClass({
 								<td className="usage-table__default">none</td>
 								<td className="usage-table__description">The number of pages to show in pagination.</td>
 							</tr>
+							<tr>
+								<td className="usage-table__prop">label</td>
+								<td className="usage-table__type">func</td>
+								<td className="usage-table__default">none</td>
+								<td className="usage-table__description">The function used to customize labels in pagination. Be aware that if you specify this prop, 'singular' and 'plural' props are ignored.</td>
+							</tr>
 						</tbody>
 					</Table>
+				</div>
+
+				<h2>Pagination with I18n</h2>
+				<div className="code-example">
+					<div className="code-example__example">
+						<Pagination
+							currentPage={2}
+							pageSize={10}
+							style={{ lineHeight: '34px', marginBottom: 0, minHeight: 34 }}
+							total={123}
+							limit={5}
+							label={labelFn}
+							/>
+					</div>
+					<ExampleSource>
+						{`
+							function labelFn(params) {
+								let count = '';
+								const { currentPage, pageSize, total } = params;
+								if (!total) {
+									count = '表示する項目がありません';
+								} else if (total > pageSize) {
+									const { start, end } = params;
+									count = total + ' 件中 ' + start + ' から ' + end + ' まで表示';
+								} else {
+									count = '全 ' + total + ' 件を表示';
+								}
+								return count;
+							}
+
+							// ...
+
+							<Pagination
+								currentPage={2}
+								pageSize={10}
+								total={30}
+								limit={5}
+								label={labelFn}
+								/>
+						`}
+					</ExampleSource>
 				</div>
 
 				<h2>Pills</h2>

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -27,14 +27,14 @@ const Page = React.createClass({
 });
 
 function range(props) {
-  const { currentPage, pageSize, total } = props;
-  if (!total) {
-    return {};
-  } else {
-    const start = (pageSize * (currentPage - 1)) + 1;
-    const end = Math.min(start + pageSize - 1, total);
-    return { start, end };
-  }
+	const { currentPage, pageSize, total } = props;
+	if (!total) {
+		return {};
+	} else {
+		const start = (pageSize * (currentPage - 1)) + 1;
+		const end = Math.min(start + pageSize - 1, total);
+		return { start, end };
+	}
 }
 
 module.exports = React.createClass({
@@ -43,7 +43,7 @@ module.exports = React.createClass({
 		className: React.PropTypes.string,
 		currentPage: React.PropTypes.number.isRequired,
 		limit: React.PropTypes.number,
-    label: React.PropTypes.func,
+		label: React.PropTypes.func,
 		onPageSelect: React.PropTypes.func,
 		pageSize: React.PropTypes.number.isRequired,
 		plural: React.PropTypes.string,
@@ -54,24 +54,24 @@ module.exports = React.createClass({
 	renderCount () {
 		let count = '';
 		let { currentPage, pageSize, plural, singular, total, label } = this.props;
-    if (typeof label === 'function') {
-      const params = Object.assign(range(this.props), { currentPage, pageSize, total });
-      count = label(params);
-    } else {
-      if (!total) {
-        count = 'No ' + (plural || 'records');
-      } else if (total > pageSize) {
-        const { start, end } = range(this.props);
-        count = `Showing ${start} to ${end} of ${total}`;
-      } else {
-        count = 'Showing ' + total;
-        if (total > 1 && plural) {
-          count += ' ' + plural;
-        } else if (total === 1 && singular) {
-          count += ' ' + singular;
-        }
-      }
-    }
+		if (typeof label === 'function') {
+			const params = Object.assign(range(this.props), { currentPage, pageSize, total });
+			count = label(params);
+		} else {
+			if (!total) {
+				count = 'No ' + (plural || 'records');
+			} else if (total > pageSize) {
+				const { start, end } = range(this.props);
+				count = `Showing ${start} to ${end} of ${total}`;
+			} else {
+				count = 'Showing ' + total;
+				if (total > 1 && plural) {
+					count += ' ' + plural;
+				} else if (total === 1 && singular) {
+					count += ' ' + singular;
+				}
+			}
+		}
 		return (
 			<div className="Pagination__count">{count}</div>
 		);

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -26,12 +26,24 @@ const Page = React.createClass({
 	},
 });
 
+function range(props) {
+  const { currentPage, pageSize, total } = props;
+  if (!total) {
+    return {};
+  } else {
+    const start = (pageSize * (currentPage - 1)) + 1;
+    const end = Math.min(start + pageSize - 1, total);
+    return { start, end };
+  }
+}
+
 module.exports = React.createClass({
 	displayName: 'Pagination',
 	propTypes: {
 		className: React.PropTypes.string,
 		currentPage: React.PropTypes.number.isRequired,
 		limit: React.PropTypes.number,
+    label: React.PropTypes.func,
 		onPageSelect: React.PropTypes.func,
 		pageSize: React.PropTypes.number.isRequired,
 		plural: React.PropTypes.string,
@@ -41,21 +53,25 @@ module.exports = React.createClass({
 	},
 	renderCount () {
 		let count = '';
-		let { currentPage, pageSize, plural, singular, total } = this.props;
-		if (!total) {
-			count = 'No ' + (plural || 'records');
-		} else if (total > pageSize) {
-			let start = (pageSize * (currentPage - 1)) + 1;
-			let end = Math.min(start + pageSize - 1, total);
-			count = `Showing ${start} to ${end} of ${total}`;
-		} else {
-			count = 'Showing ' + total;
-			if (total > 1 && plural) {
-				count += ' ' + plural;
-			} else if (total === 1 && singular) {
-				count += ' ' + singular;
-			}
-		}
+		let { currentPage, pageSize, plural, singular, total, label } = this.props;
+    if (typeof label === 'function') {
+      const params = Object.assign(range(this.props), { currentPage, pageSize, total });
+      count = label(params);
+    } else {
+      if (!total) {
+        count = 'No ' + (plural || 'records');
+      } else if (total > pageSize) {
+        const { start, end } = range(this.props);
+        count = `Showing ${start} to ${end} of ${total}`;
+      } else {
+        count = 'Showing ' + total;
+        if (total > 1 && plural) {
+          count += ' ' + plural;
+        } else if (total === 1 && singular) {
+          count += ' ' + singular;
+        }
+      }
+    }
 		return (
 			<div className="Pagination__count">{count}</div>
 		);


### PR DESCRIPTION
This PR resolves #182.

In most cases, `singular` and `plural` props are enough for customization of pagination's labels.
Some users (including me) have a problem on i18n.
I don't prefer the explosion of props, I choose a format function. This is not friendly for beginners, but a topic of i18n is a headache for advanced users.

Any feedbacks are welcome 😃 
