### PR TITLE
Add 'size' prop to options for FormSelect

### DIFF
--- a/less/components/FormInput.less
+++ b/less/components/FormInput.less
@@ -181,7 +181,7 @@ textarea.FormInput {
 		display: block;
 		fill: @text-color;
 		left: 50%;
-		margin: -5.5px 0 0 -3.5px;
+		transform: translate(-50%, -50%);
 		position: absolute;
 		top: 50%;
 	}

--- a/less/components/FormInput.less
+++ b/less/components/FormInput.less
@@ -165,6 +165,7 @@ textarea.FormInput {
 
 .FormSelect__arrows {
 	bottom: 0;
+	height: @component-height;
 	line-height: @component-height;
 	pointer-events: none;
 	position: absolute;
@@ -172,9 +173,19 @@ textarea.FormInput {
 	text-align: center;
 	width: @component-height;
 
+	&--lg { font-size: @font-size-lg }
+	&--sm { font-size: @font-size-sm }
+	&--xs { font-size: @font-size-xs }
+
 	& > svg {
+		display: block;
 		fill: @text-color;
+		left: 50%;
+		margin: -5.5px 0 0 -3.5px;
+		position: absolute;
+		top: 50%;
 	}
+
 }
 .FormSelect__arrows--disabled > svg {
 	fill: @gray-light;

--- a/site/src/pages/Forms.js
+++ b/site/src/pages/Forms.js
@@ -437,6 +437,38 @@ var Forms = React.createClass({
 						`}
 					</ExampleSource>
 				</div>
+				<div className="code-example">
+					<div className="code-example__example">
+						<FormField label="Select" htmlFor="supported-controls-select">
+							<FormSelect name="supported-controls-select" options={controlOptions} firstOption="Select" onChange={updateSelect} />
+						</FormField>
+						<FormField label="Large Select" htmlFor="supported-controls-select-lg">
+							<FormSelect name="supported-controls-select-lg" size="lg" options={controlOptions} firstOption="Select Large" onChange={updateSelect} />
+						</FormField>
+						<FormField label="Small Select" htmlFor="supported-controls-select-sm">
+							<FormSelect name="supported-controls-select-sm" size="sm" options={controlOptions} firstOption="Select Small" onChange={updateSelect} />
+						</FormField>
+						<FormField label="Extra Small Select" htmlFor="supported-controls-select-xs">
+							<FormSelect name="supported-controls-select-xs" size="xs" options={controlOptions} firstOption="Select Extra Small" onChange={updateSelect} />
+						</FormField>
+					</div>
+					<ExampleSource>
+						{`
+							<FormField label="Select" htmlFor="supported-controls-select">
+								<FormSelect name="supported-controls-select" options={controlOptions} firstOption="Select" onChange={updateSelect} />
+							</FormField>
+							<FormField label="Large Select" htmlFor="supported-controls-select-lg">
+								<FormSelect name="supported-controls-select-lg" size="lg" options={controlOptions} firstOption="Select Large" onChange={updateSelect} />
+							</FormField>
+							<FormField label="Small Select" htmlFor="supported-controls-select-sm">
+								<FormSelect name="supported-controls-select-sm" size="sm" options={controlOptions} firstOption="Select Small" onChange={updateSelect} />
+							</FormField>
+							<FormField label="Extra Small Select" htmlFor="supported-controls-select-xs">
+								<FormSelect name="supported-controls-select-xs" size="xs" options={controlOptions} firstOption="Select Extra Small" onChange={updateSelect} />
+							</FormField>
+						`}
+					</ExampleSource>
+				</div>
 
 
 

--- a/src/components/FormSelect.js
+++ b/src/components/FormSelect.js
@@ -24,6 +24,7 @@ module.exports = React.createClass({
 		prependEmptyOption: React.PropTypes.bool,
 		required: React.PropTypes.bool,
 		requiredMessage: React.PropTypes.string,
+		size: React.PropTypes.oneOf(['lg', 'sm', 'xs']),
 		value: React.PropTypes.string,
 	},
 	getDefaultProps () {
@@ -79,14 +80,19 @@ module.exports = React.createClass({
 		this.setState(newState);
 	},
 	renderIcon (icon) {
-		let iconClassname = classNames('FormSelect__arrows', {
-			'FormSelect__arrows--disabled': this.props.disabled,
-		});
+		const { size } = this.props;
+		let iconClassname = classNames(
+			'FormSelect__arrows',
+			{
+				'FormSelect__arrows--disabled': this.props.disabled,
+			},
+			size ? ('FormSelect__arrows--' + size) : null
+		);
 		return <span dangerouslySetInnerHTML={{ __html: icon }} className={iconClassname} />;
 	},
 	render () {
 		// props
-		let props = blacklist(this.props, 'prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'className');
+		let props = blacklist(this.props, 'prependEmptyOption', 'firstOption', 'alwaysValidate', 'htmlFor', 'id', 'label', 'onChange', 'options', 'required', 'requiredMessage', 'className', 'size');
 
 		// classes
 		let componentClass = classNames('FormField', {
@@ -115,11 +121,17 @@ module.exports = React.createClass({
 			);
 		}
 
+		const selectClasses = classNames(
+			'FormInput',
+			'FormSelect',
+			this.props.size ? ('FormInput--' + this.props.size) : null
+		);
+
 		return (
 			<div className={componentClass}>
 				{componentLabel}
 				<div className="u-pos-relative">
-					<select className="FormInput FormSelect" id={forAndID} onChange={this.handleChange} onBlur={this.handleBlur} {...props}>
+					<select className={selectClasses} id={forAndID} onChange={this.handleChange} onBlur={this.handleBlur} {...props}>
 						{options}
 					</select>
 					{this.renderIcon(icons.selectArrows)}


### PR DESCRIPTION
This adds support for sizes `lg`, `sm`, and `xs` for the `FormSelect` component. In order to center the arrows the SVG is now displayed as block and centered via `position: absolute`.